### PR TITLE
Allows to use  preset name and options at the same time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ function mdReactFactory(options={}) {
     onGenerateKey=(tag, index) => `mdrct-${tag}-${index}`,
     className } = options;
 
-  let md = markdown(markdownOptions || presetName)
+  let md = markdown(presetName || 'default', markdownOptions)
     .enable(enableRules)
     .disable(disableRules);
 


### PR DESCRIPTION
As it is designed by markdown-it api, both should be possible, options don't replace a full preset.